### PR TITLE
Optimize gpu sieving

### DIFF
--- a/Source/cdatastorage.cpp
+++ b/Source/cdatastorage.cpp
@@ -56,7 +56,7 @@ namespace net
             // *****************************************************************************
             void CDataStorage::clear(void)
             {
-                m_storage = thrust::host_vector<char>(m_storageSize, m_unset);
+                m_storage = std::vector<char>(m_storageSize, m_unset);
             }
 
             // *****************************************************************************

--- a/Source/cdatastorage.h
+++ b/Source/cdatastorage.h
@@ -23,7 +23,7 @@
 #include <map>
 #include <stdlib.h>
 #include <string>
-#include <thrust/host_vector.h>
+#include <vector>
 
 // *****************************************************************************
 // Namespace of Sieve
@@ -124,7 +124,7 @@ namespace net
                 /// <summary>
                 /// Internal storage for primes
                 /// </summary>
-                thrust::host_vector<char> m_storage;
+                std::vector<char> m_storage;
 
             private:
                 /// <summary>


### PR DESCRIPTION
Still not faster than the CPU version, but better than before 😅 

* Memory is now only copied from device to host and not both ways each iteration.
* Memory on device is only allocated once and freed after the sieving operation.
* Kernel is a lot simper (less divergent branches means a lot more performance), it takes the kernel thread idx as the multiplier for the prime (excluding 0 and 1) and just checkes if the write is in bounds before doing it. This way every kernel thread except the very last ones have do to some work, where before we had a lot of idle threads depending on the result of the (expensive) modulo operation.